### PR TITLE
Modified build.sh, it removes bin folder at the end of the process

### DIFF
--- a/SFML_VSCode/build.sh
+++ b/SFML_VSCode/build.sh
@@ -286,4 +286,8 @@ for target in $BUILD_TARGETS; do
 
 done
 
+rm -r ./bin
+
+
+
 exit 0

--- a/SFML_VSCode/src/app_modules/system/function/GameSystem.h
+++ b/SFML_VSCode/src/app_modules/system/function/GameSystem.h
@@ -55,6 +55,7 @@ public:
 
     sf::Mouse::Button m_keyMouse;
     sf::Keyboard::Key m_keyboard;
+
 };
 }
 #endif // GAMESYSTEM_H_INCLUDED


### PR DESCRIPTION
(c'est juste on va dire pour m'entraîner un peu avec GitHub, comme tu peux le voir j'ai modifié le fichier build.sh, il supprime le dossier bin parce qu'il est inutile puisque l'exe est dans build)
Je vais essayer de faire d'avantage de contributions.
En fait ce qu'on a trouvé un peu redondant, c'est qu'il y a trois projets et que la GAME ENGINE est dupliqué trois fois. Le deuxième point, c'est que la GAME ENGINE, is::Engine, est mélangé dans le code du jeu et dans d'autres codes ; tout cela n'est pas séparé explicitement. Normalement la GAME ENGINE doit être comprise dans un seul projet tout seul et à l'extérieur on peut rajouter un dossier qui contient un exemple d'utilisation.
Voili Voilou