### PR TITLE
Fix potential vulnerability in cloned code

### DIFF
--- a/libs/SDL2_jpeg/src/jdmaster.c
+++ b/libs/SDL2_jpeg/src/jdmaster.c
@@ -300,7 +300,8 @@ master_selection (j_decompress_ptr cinfo)
     if (cinfo->raw_data_out)
       ERREXIT(cinfo, JERR_NOTIMPL);
     /* 2-pass quantizer only works in 3-component color space. */
-    if (cinfo->out_color_components != 3) {
+    if (cinfo->out_color_components != 3 ||
+        cinfo->out_color_space == JCS_RGB565) {
       cinfo->enable_1pass_quant = TRUE;
       cinfo->enable_external_quant = FALSE;
       cinfo->enable_2pass_quant = FALSE;

--- a/libs/SDL2_jpeg/src/jquant2.c
+++ b/libs/SDL2_jpeg/src/jquant2.c
@@ -1257,7 +1257,8 @@ jinit_2pass_quantizer (j_decompress_ptr cinfo)
   cquantize->error_limiter = NULL;
 
   /* Make sure jdmaster didn't give me a case I can't handle */
-  if (cinfo->out_color_components != 3)
+  if (cinfo->out_color_components != 3 ||
+      cinfo->out_color_space == JCS_RGB565)
     ERREXIT(cinfo, JERR_NOTIMPL);
 
   /* Allocate the histogram/inverse colormap storage */


### PR DESCRIPTION
This PR fixes a potential security vulnerability that was cloned from `libjpeg-turbo/libjpeg-turbo` but did not receive the security patch.

**Vulnerability Details:**

* **Original Fix**: https://github.com/libjpeg-turbo/libjpeg-turbo/commit/42ce199c9cfe129e5e21afd48dfe757a6acf87c4

**What this PR does:** This PR applies the same security patch that was applied to the original repository to eliminate the potential vulnerability in the cloned code.

**References:**

* https://github.com/libjpeg-turbo/libjpeg-turbo/commit/42ce199c9cfe129e5e21afd48dfe757a6acf87c4

Please review and merge this PR to ensure your repository is protected against this vulnerability.