### PR TITLE
Fix MainObject::setXOffset() overwriting the Y offset

### DIFF
--- a/app/src/main/cpp/MainObject.cpp
+++ b/app/src/main/cpp/MainObject.cpp
@@ -326,7 +326,7 @@ void MainObject::setImageAngle(float val)
 
 void MainObject::setXOffset(float val)
 {
-    setXYOffset(val, m_xOffset);
+    setXYOffset(val, m_yOffset);
 }
 
 void MainObject::setYOffset(float val)


### PR DESCRIPTION
Fixes #9

### Problem

`MainObject::setXOffset()` passes `m_xOffset` where `setXYOffset()` expects its `y` argument:

```cpp
void MainObject::setXOffset(float val)
{
    setXYOffset(val, m_xOffset);   // m_xOffset used as the y argument
}

void MainObject::setYOffset(float val)
{
    setXYOffset(m_xOffset, val);   // correct
}
```

`setXYOffset(x, y)` assigns **both** members and then calls `updateSDMsprite()`, so setting the X offset also replaces `m_yOffset` with the *previous* X offset and repositions the sprite on the Y axis. The header documents the two setters as independent (`/// Set the x offset` / `/// Set the y offset`), and `setYOffset()` already behaves that way.

### Change

One line, `m_xOffset` -> `m_yOffset`.

### Verification

Built against the SFML backend (Linux, GCC, `-std=c++17`); the translation unit compiles clean.

Behaviour before and after, using a local harness against the real class:

```cpp
is::MainObject obj;
obj.setXYOffset(10.f, 20.f);
obj.setXOffset(5.f);
```

| | `getXOffset()` | `getYOffset()` |
|---|---|---|
| `4.0.x` (before) | 5 | **10** — expected 20 |
| this PR | 5 | 20 |

The mirrored case (`setYOffset(7)` preserving `m_xOffset == 10`) passes both before and after, confirming only the X setter was affected.

No test file is included: the repository vendors `catch.hpp` but has no test suite or build target wired up, so adding one would take this well past a single-concern change. Happy to add tests if you would like the harness upstreamed.
